### PR TITLE
Add fuzz tests for IndexFactory

### DIFF
--- a/test/foundry/ContractDeployer.sol
+++ b/test/foundry/ContractDeployer.sol
@@ -214,11 +214,11 @@ contract ContractDeployer is Test, UniswapFactoryByteCode, UniswapWETHByteCode, 
 
     }
 
-    function deployTokens() public returns(Token[11] memory) {
+    function deployTokens(uint256 initialSupply) public returns(Token[11] memory) {
         Token[11] memory tokens;
         
         for (uint256 i = 0; i < 11; i++) {
-            tokens[i] = new Token(1000000e18);
+            tokens[i] = new Token(initialSupply);
         }
 
         return tokens;
@@ -236,8 +236,8 @@ contract ContractDeployer is Test, UniswapFactoryByteCode, UniswapWETHByteCode, 
         return (priceOracleAddress, factoryAddress, wethAddress, routerAddress, positionManagerAddress);
     }
 
-    function deployAllContracts() public {
-        Token[11] memory tokens = deployTokens();
+    function deployAllContracts(uint initialSupply) public {
+        Token[11] memory tokens = deployTokens(initialSupply);
         token0 = tokens[0];
         token1 = tokens[1];
         token2 = tokens[2];

--- a/test/foundry/IndexToken.t.sol
+++ b/test/foundry/IndexToken.t.sol
@@ -48,7 +48,7 @@ contract CounterTest is Test, ContractDeployer {
     function setUp() public {
         // ContractDeployer deployer = new ContractDeployer();
         // (link, oracle, indexToken) = deployer.deployContracts();
-        deployAllContracts();
+        deployAllContracts(1000000e18);
         // (link, oracle, indexToken,,,) = deployContracts();
         indexToken.setMinter(minter);
         /**

--- a/test/foundry/IndexTokenFactoryWETH.t.sol
+++ b/test/foundry/IndexTokenFactoryWETH.t.sol
@@ -45,7 +45,7 @@ contract CounterTest is Test, ContractDeployer {
 
     function setUp() public {
         
-        deployAllContracts();
+        deployAllContracts(1000000e18);
         addLiquidityETH(positionManager, factoryAddress, token0, wethAddress, 1000e18, 1e18);
         addLiquidityETH(positionManager, factoryAddress, token1, wethAddress, 1000e18, 1e18);
         addLiquidityETH(positionManager, factoryAddress, token2, wethAddress, 1000e18, 1e18);

--- a/test/foundry/TestIssuance10.t.sol
+++ b/test/foundry/TestIssuance10.t.sol
@@ -45,7 +45,7 @@ contract CounterTest is Test, ContractDeployer {
 
     function setUp() public {
         
-        deployAllContracts();
+        deployAllContracts(1000000e18);
         addLiquidityETH(positionManager, factoryAddress, token0, wethAddress, 1000e18, 1e18);
         addLiquidityETH(positionManager, factoryAddress, token1, wethAddress, 1000e18, 1e18);
         addLiquidityETH(positionManager, factoryAddress, token2, wethAddress, 1000e18, 1e18);

--- a/test/foundry/fuzz/IndexTokenFactory.fuzz.t.sol
+++ b/test/foundry/fuzz/IndexTokenFactory.fuzz.t.sol
@@ -2,27 +2,30 @@
 pragma solidity ^0.8.7;
 
 import "forge-std/Test.sol";
-import "../../contracts/token/IndexToken.sol";
-import "../../contracts/factory/IndexFactory.sol";
-// import "../../contracts/test/TestSwap.sol";
+import "../../../contracts/token/IndexToken.sol";
+import "../../../contracts/factory/IndexFactory.sol";
+// import "../../../contracts/test/TestSwap.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import "@uniswap/v3-periphery/contracts/libraries/TransferHelper.sol";
 import "@uniswap/v3-periphery/contracts/interfaces/IQuoter.sol";
-import "../../contracts/test/MockV3Aggregator.sol";
-import "../../contracts/test/MockApiOracle.sol";
-import "../../contracts/test/LinkToken.sol";
-import "../../contracts/interfaces/IUniswapV3Pool.sol";
-import "../../contracts/test/MockV3Aggregator.sol";
+import "../../../contracts/test/MockV3Aggregator.sol";
+import "../../../contracts/test/MockApiOracle.sol";
+import "../../../contracts/test/LinkToken.sol";
+import "../../../contracts/interfaces/IUniswapV3Pool.sol";
+import "../../../contracts/test/MockV3Aggregator.sol";
 
-import "./ContractDeployer.sol";
+import "../ContractDeployer.sol";
 
-contract CounterTest is Test, ContractDeployer {
+contract IndexTokenFactoryFuzzTests is Test, ContractDeployer {
 
     using stdStorage for StdStorage;
 
     uint256 internal constant SCALAR = 1e20;
+
+    uint256 internal constant TOKEN_LIQUIDITY_LIMIT = 1000000e18;
+    uint256 internal constant WETH_LIQUIDITY_LIMIT = 1000e18;
 
     
     uint256 mainnetFork;
@@ -46,18 +49,17 @@ contract CounterTest is Test, ContractDeployer {
 
     function setUp() public {
         
-        deployAllContracts(1000000e18);
-        addLiquidityETH(positionManager, factoryAddress, token0, wethAddress, 1000e18, 1e18);
-        addLiquidityETH(positionManager, factoryAddress, token1, wethAddress, 1000e18, 1e18);
-        addLiquidityETH(positionManager, factoryAddress, token2, wethAddress, 1000e18, 1e18);
-        addLiquidityETH(positionManager, factoryAddress, token3, wethAddress, 1000e18, 1e18);
-        addLiquidityETH(positionManager, factoryAddress, token4, wethAddress, 1000e18, 1e18);
-        addLiquidityETH(positionManager, factoryAddress, usdt, wethAddress, 1000e18, 1e18);
+        deployAllContracts(TOKEN_LIQUIDITY_LIMIT * 1000);
+        addLiquidityETH(positionManager, factoryAddress, token0, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
+        addLiquidityETH(positionManager, factoryAddress, token1, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
+        addLiquidityETH(positionManager, factoryAddress, token2, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
+        addLiquidityETH(positionManager, factoryAddress, token3, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
+        addLiquidityETH(positionManager, factoryAddress, token4, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
+        addLiquidityETH(positionManager, factoryAddress, usdt, wethAddress, TOKEN_LIQUIDITY_LIMIT, WETH_LIQUIDITY_LIMIT);
         
     }
 
     function testInitialized() public {
-        // counter.increment();
         assertEq(indexToken.owner(), address(this));
         assertEq(indexToken.feeRatePerDayScaled(), 1e18);
         assertEq(indexToken.feeTimestamp(), block.timestamp);
@@ -125,109 +127,25 @@ contract CounterTest is Test, ContractDeployer {
         
     }
 
-    
-    function testIssuanceWithEth() public {
-        uint startAmount = 1e14;
-        
 
+    function testFuzzIssuanceWithTokens(uint256 amount) public {
+        vm.assume(amount + 1e18 < TOKEN_LIQUIDITY_LIMIT);    
         updateOracleList();
         
         factory.proposeOwner(owner);
         vm.startPrank(owner);
         factory.transferOwnership(owner);
         vm.stopPrank();
-        payable(add1).transfer(11e18);
+        usdt.transfer(add1, amount + 1e18);
         vm.startPrank(add1);
-        
-        factory.issuanceIndexTokensWithEth{value: (1e18*1001)/1000}(1e18);
+
+        usdt.approve(address(factory), amount + 1e18);
+        factory.issuanceIndexTokens(address(usdt), amount, 3000);
         factory.redemption(indexToken.balanceOf(address(add1)), address(weth), 3);
-    }
-
-    function testIssuanceWithTokens() public {
-        uint startAmount = 1e14;
-        
-        updateOracleList();
-        
-        factory.proposeOwner(owner);
-        vm.startPrank(owner);
-        factory.transferOwnership(owner);
-        vm.stopPrank();
-        usdt.transfer(add1, 1001e18);
-        vm.startPrank(add1);
-        
-        usdt.approve(address(factory), 1001e18);
-        factory.issuanceIndexTokens(address(usdt), 1000e18, 3000);
-        factory.redemption(indexToken.balanceOf(address(add1)), address(weth), 3);
-    }
-
-    
-    function testIssuanceWithTokensOutput() public {
-        
-       
-        updateOracleList();
-        
-        factory.proposeOwner(owner);
-        vm.startPrank(owner);
-        factory.transferOwnership(owner);
-        vm.stopPrank();
-        usdt.transfer(add1, 1001e18);
-        vm.startPrank(add1);
-        usdt.approve(address(factory), 1001e18);
-        factory.issuanceIndexTokens(address(usdt), 1000e18, 3000);
-        console.log("index token balance after isssuance", indexToken.balanceOf(address(add1)));
-        console.log("portfolio value after issuance", factoryStorage.getPortfolioBalance());
-        uint reallOut = factory.redemption(indexToken.balanceOf(address(add1)), address(usdt), 3000);
-        console.log("index token balance after redemption", indexToken.balanceOf(address(add1)));
-        console.log("portfolio value after redemption", factoryStorage.getPortfolioBalance());
-        console.log("real out", reallOut);
-        console.log("usdt after redemption", usdt.balanceOf(add1));
-    }
-    
-    
-
-    
-    /**
-    function testGetPrice() public {
-        
-        address pool = factoryV3.getPool(
-            wethAddress,
-            address(token0),
-            3000
-        );
-        
-       (
-            uint160 sqrtPriceX96,
-            int24 tick,
-            uint16 observationIndex,
-            uint16 observationCardinality,
-            uint16 observationCardinalityNext,
-            uint8 feeProtocol,
-            bool unlocked
-        ) = IUniswapV3Pool(pool).slot0();
-        //swap
-        weth.deposit{value:1e16}();
-        weth.approve(address(swapRouter), 1e16);
-        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
-        .ExactInputSingleParams({
-            tokenIn: wethAddress,
-            tokenOut: address(token0),
-            // pool fee 0.3%
-            fee: 3000,
-            recipient: address(this),
-            deadline: block.timestamp,
-            amountIn: 1e16,
-            amountOutMinimum: 0,
-            // NOTE: In production, this value can be used to set the limit
-            // for the price the swap will push the pool to,
-            // which can help protect against price impact
-            sqrtPriceLimitX96: 0
-        });
-        uint finalAmountOut = swapRouter.exactInputSingle(params);
+        assertEq(indexToken.balanceOf(add1), 0);
 
     }
 
-
-    */
-
+    
     
 }


### PR DESCRIPTION
- Modifies `deployTokens` to take in a `uint256` param to allow the caller to specify an `initialSupply` for all the tokens. 
- Adds `IndexTokenFactory.fuzz.t.sol`, which includes a sample fuzz test for the `issuanceIndexTokens` function in `IndexFactory`. 

This PR is WIP. 